### PR TITLE
Add possibility to update existing license header

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,11 +196,11 @@ func addLicense(path string, updateOldLicense bool, fmode os.FileMode, tmpl *tem
 	if err != nil {
 		return false, err
 	}
+	if isGenerated(b) {
+		return false, nil
+	}
 	if hasLicense(b) {
-		if isGenerated(b) || !updateOldLicense {
-			return false, nil
-		}
-		if isOutdated(b, data.Year) {
+		if updateOldLicense && isOutdated(b, data.Year) {
 			b, err := updateExistingLicense(b, data.Year)
 			if err != nil {
 				return false, err

--- a/main_test.go
+++ b/main_test.go
@@ -64,6 +64,31 @@ func TestInitial(t *testing.T) {
 	}
 }
 
+func TestUpdate(t *testing.T) {
+	if os.Getenv("RUNME") != "" {
+		main()
+		return
+	}
+
+	tmp := tempDir(t)
+	t.Logf("tmp dir: %s", tmp)
+	run(t, "cp", "-r", "testdata/update/initial", tmp)
+
+	// run at least 2 times to ensure the program is idempotent
+	for i := 0; i < 2; i++ {
+		t.Logf("run #%d", i)
+		targs := []string{"-test.run=TestUpdate"}
+		cargs := []string{"-l", "apache", "-c", "Google LLC", "-y", "2018", "-u", tmp}
+		c := exec.Command(os.Args[0], append(targs, cargs...)...)
+		c.Env = []string{"RUNME=1"}
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("%v\n%s", err, out)
+		}
+
+		run(t, "diff", "-r", filepath.Join(tmp, "initial"), "testdata/update/expected")
+	}
+}
+
 func TestMultiyear(t *testing.T) {
 	if os.Getenv("RUNME") != "" {
 		main()

--- a/testdata/update/expected/actual_2010_2018.go
+++ b/testdata/update/expected/actual_2010_2018.go
@@ -1,0 +1,21 @@
+// Copyright 2010-2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/expected/actual_2018.go
+++ b/testdata/update/expected/actual_2018.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/expected/empty.go
+++ b/testdata/update/expected/empty.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/expected/old_2010.go
+++ b/testdata/update/expected/old_2010.go
@@ -1,0 +1,21 @@
+// Copyright 2010-2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/expected/old_2010_2015.go
+++ b/testdata/update/expected/old_2010_2015.go
@@ -1,0 +1,21 @@
+// Copyright 2010-2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/initial/actual_2010_2018.go
+++ b/testdata/update/initial/actual_2010_2018.go
@@ -1,0 +1,21 @@
+// Copyright 2010-2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/initial/actual_2018.go
+++ b/testdata/update/initial/actual_2018.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/initial/empty.go
+++ b/testdata/update/initial/empty.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/initial/old_2010.go
+++ b/testdata/update/initial/old_2010.go
@@ -1,0 +1,21 @@
+// Copyright 2010 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/testdata/update/initial/old_2010_2015.go
+++ b/testdata/update/initial/old_2010_2015.go
@@ -1,0 +1,21 @@
+// Copyright 2010-2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}


### PR DESCRIPTION
This change allows to update existing license headers, eg.
```
// Copyright 2018 Google LLC
```
to
```
// Copyright 2018-2021 Google LLC
```

To enable this mode flag `-u` must be set, example of use:
```
addlicense -c "CompanyName" -f LICENSE.tmpl  -v -u  ~/path_to_files/
```

It can be set up as commit pre-hook to change only files which are going to be commited:
`.git/hooks/pre-commit`:
```
git diff --staged --name-only -z | xargs -0  ./addlicense -c "CompanyName" -f LICENSE.tmpl -u
```